### PR TITLE
query updates

### DIFF
--- a/Custom reports site/bib holds where items have volumes.sql
+++ b/Custom reports site/bib holds where items have volumes.sql
@@ -1,0 +1,39 @@
+SELECT DISTINCT
+rm.record_type_code||rm.record_num||'a' AS bib_number,
+b.best_title AS title,
+m.name AS mat_type,
+rmp.record_type_code||rmp.record_num||'a' AS patron_number,
+h.placed_gmt::DATE AS date_placed,
+CASE
+	WHEN h.is_frozen = TRUE THEN 'True'
+	ELSE 'False'
+END AS is_frozen,
+h.expires_gmt::DATE AS expiration_date
+
+FROM
+sierra_view.bib_record_property b
+JOIN
+sierra_view.bib_record_item_record_link l
+ON
+b.bib_record_id = l.bib_record_id
+JOIN
+sierra_view.varfield v
+ON
+l.item_record_id = v.record_id AND v.varfield_type_code = 'v'
+JOIN
+sierra_view.record_metadata rm
+ON
+b.bib_record_id = rm.id
+JOIN
+sierra_view.material_property_myuser m
+ON
+b.material_code = m.code
+JOIN
+sierra_view.hold h
+ON b.bib_record_id = h.record_id
+JOIN
+sierra_view.record_metadata rmp
+ON
+h.patron_record_id = rmp.id
+
+WHERE h.pickup_location_code ~ '{{location}}' 

--- a/Custom reports site/diversity analysis.sql
+++ b/Custom reports site/diversity analysis.sql
@@ -47,7 +47,7 @@ CASE
 END AS topic,
 CASE
 	WHEN d.index_entry ~ '((\yfiction)|(pictorial works)|(tales)|(^\y(?!\w*biography)\w*(comic books strips etc))|(^\y(?!\w*biography)\w*(graphic novels))|(\ydrama)|((?<!hi)stories))(( [a-z]+)?)(( translations into [a-z]+)?)$' AND b.material_code NOT IN ('7','8','b','e','j','k','m','n')
-	AND NOT (ml.bib_level_code = 'm' AND ml.record_type_code = 'a' AND f.p33 IN ('0','e','i','p','s')) THEN TRUE
+	AND NOT (ml.bib_level_code = 'm' AND ml.record_type_code = 'a' AND f.p33 IN ('0','e','i','p','s','','c')) THEN TRUE
 	ELSE FALSE
 END AS is_fiction	
 

--- a/Library requests/cam big waive update.sql
+++ b/Library requests/cam big waive update.sql
@@ -11,7 +11,7 @@ f.item_record_metadata_id = i.id AND  i.location_code ~ '^ca\w{1}(j|y)'
 AND f.charge_code IN ('3','5')
 GROUP BY 1
 HAVING
-COUNT(*) FILTER(WHERE f.assessed_gmt::DATE BETWEEN '2022-03-01' AND '2022-04-30') >0
+COUNT(*) FILTER(WHERE f.assessed_gmt::DATE BETWEEN '2022-07-01' AND '2022-08-31') >0
 )
 
 SELECT
@@ -91,5 +91,5 @@ ON
 f.patron_record_id = email.record_id AND email.varfield_type_code = 'z'
 
 WHERE f.charge_code IN ('3','5')
-AND f.assessed_gmt::DATE BETWEEN '2022-05-01' AND '2022-06-30'-- CURRENT_DATE - INTERVAL '1 week'
+AND f.assessed_gmt::DATE BETWEEN '2022-07-01' AND '2022-08-31'-- CURRENT_DATE - INTERVAL '1 week'
 ORDER BY 2,1

--- a/Library requests/mld weekly fines paid.sql
+++ b/Library requests/mld weekly fines paid.sql
@@ -1,0 +1,20 @@
+SELECT 
+f.paid_date_gmt::DATE AS DATE,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code IN ('2','6'))::MONEY,0.00::MONEY) AS overdue,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code = '5')::MONEY,0.00::MONEY) AS lost_book,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code = '3')::MONEY,0.00::MONEY) AS replacement,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code = '1')::MONEY,0.00::MONEY) AS manual_charge,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code = '4')::MONEY,0.00::MONEY) AS adjustment,
+COALESCE(SUM(f.paid_now_amt) FILTER(WHERE f.charge_type_code BETWEEN '1' AND '6')::MONEY,0.00::MONEY) AS total
+
+FROM
+sierra_view.fines_paid f
+
+WHERE
+f.tty_num::VARCHAR ~ '^50'
+AND f.payment_status_code NOT IN ('0','3')
+AND f.paid_now_amt > 0
+AND f.paid_date_gmt::DATE >= CURRENT_DATE - INTERVAL '1 week'
+
+GROUP BY 1
+ORDER BY 1

--- a/Library requests/som graphic novel order status.sql
+++ b/Library requests/som graphic novel order status.sql
@@ -1,0 +1,51 @@
+SELECT
+DISTINCT rm.record_type_code||rm.record_num||'a' AS bib_number,
+b.best_title,
+b.best_author,
+COUNT(DISTINCT i.id) AS item_total,
+COUNT(DISTINCT o.id) AS order_total,
+COUNT(DISTINCT o.id) FILTER (WHERE o.order_status_code IN ('o','q')) AS open_order_total,
+SUM(i.checkout_total + i.renewal_total) AS total_circ
+
+FROM
+sierra_view.bib_record_property b
+JOIN
+sierra_view.record_metadata rm
+ON
+b.bib_record_id = rm.id
+/*JOIN
+sierra_view.phrase_entry d
+ON
+b.bib_record_id = d.record_id AND d.index_tag = 'd'
+AND d.is_permuted = FALSE AND d.index_entry ~ '(comic books strips etc)|(graphic novels)'*/
+JOIN
+sierra_view.bib_record_item_record_link l
+ON
+b.bib_record_id = l.bib_record_id
+LEFT JOIN
+sierra_view.item_record_property ip
+ON
+l.item_record_id = ip.item_record_id AND ip.call_number_norm ~ '^graphic'
+LEFT JOIN
+sierra_view.item_record i
+ON
+ip.item_record_id = i.id AND i.location_code ~ '^so' AND i.itype_code_num <= '7'
+LEFT JOIN
+sierra_view.bib_record_order_record_link ol
+ON
+b.bib_record_id = ol.bib_record_id
+LEFT JOIN
+sierra_view.order_record o
+ON
+ol.order_record_id = o.id AND o.accounting_unit_code_num = '31'
+LEFT JOIN
+sierra_view.order_record_cmf cmf
+ON
+o.id = cmf.order_record_id AND cmf.location_code ~ '^som'
+JOIN
+sierra_view.fund_master fm
+ON
+cmf.fund_code::INT = fm.code_num AND fm.accounting_unit_id = '32' AND fm.code IN ('cagra','cagrahub')
+
+GROUP BY 1,2,3
+LIMIT 500

--- a/Library requests/som icurate extract.sql
+++ b/Library requests/som icurate extract.sql
@@ -17,8 +17,9 @@ LEFT JOIN
 sierra_view.item_record i
 ON
 l.item_record_id = i.id  
-AND i.location_code ~ '^som'-- AND SUBSTRING(i.location_code,4,1) != 'j'
-AND i.item_status_code NOT IN ('w')
+AND i.location_code ~ '^so'-- AND SUBSTRING(i.location_code,4,1) != 'j'
+AND i.item_status_code NOT IN ('w','m','$')
+AND i.icode1 != '25'
 LEFT JOIN
 sierra_view.bib_record_order_record_link ol
 ON
@@ -26,7 +27,7 @@ b.bib_record_id = ol.bib_record_id
 LEFT JOIN
 sierra_view.order_record o
 ON
-ol.order_record_id = o.id AND o.accounting_unit_code_num = '2'
+ol.order_record_id = o.id AND o.accounting_unit_code_num = '31'
 LEFT JOIN
 sierra_view.varfield v
 ON

--- a/Library requests/wwd audiobook counts.sql
+++ b/Library requests/wwd audiobook counts.sql
@@ -1,0 +1,14 @@
+SELECT
+i.itype_code_num,
+COUNT (i.id)
+FROM
+sierra_view.item_record i
+JOIN
+sierra_view.item_record_property ip
+ON
+i.id = ip.item_record_id
+WHERE
+i.location_code ~ '^ww' AND i.itype_code_num IN ('36', '37','125','173')
+AND ip.call_number_norm !~ '^great courses'
+
+GROUP BY 1

--- a/Misc Queries/Circulation/checkout table errors.sql
+++ b/Misc Queries/Circulation/checkout table errors.sql
@@ -24,5 +24,5 @@ o.patron_record_id = rmp.id
 WHERE
 o.due_gmt <= '1970-01-01' --for checkout
 --o.due_date_gmt <= '1970-01-01' AND o.op_code = 'o'--for circ_trans
---o.item_record_id = '450989861206'
+--o.item_record_id = '450987524491'
 --AND o.patron_record_id = '481039292455'

--- a/Misc Queries/Circulation/old claims returned.sql
+++ b/Misc Queries/Circulation/old claims returned.sql
@@ -1,0 +1,26 @@
+SELECT 
+DISTINCT i.location_code,
+ i.barcode,
+  TRIM(regexp_replace(iprop.call_number,'\|.',' ','g')),
+  v.field_content,
+  bprop.best_title,
+  vm.field_content,
+  i.item_status_code,
+  CAST(record_metadata.record_last_updated_gmt AS DATE) 
+
+FROM sierra_view.item_view i
+LEFT JOIN sierra_view.varfield v 
+ON v.record_id = i.id AND v.varfield_type_code = 'v'
+LEFT JOIN sierra_view.varfield vm
+ON i.id = vm.record_id AND vm.varfield_type_code = 'x' AND vm.field_content LIKE '%Claimed%'
+JOIN sierra_view.item_record_property iprop ON i.id = iprop.item_record_id 
+JOIN sierra_view.bib_record_item_record_link bilink ON bilink.item_record_id = i.id 
+JOIN sierra_view.bib_record_property bprop ON bilink.bib_record_id = bprop.bib_record_id 
+JOIN sierra_view.record_metadata ON record_metadata.id = i.id 
+JOIN sierra_view.itype_property ip ON i.itype_code_num = ip.code_num 
+JOIN sierra_view.itype_property_name it ON ip.id = it.itype_property_id
+
+WHERE i.item_status_code = 'z' 
+AND (current_date - record_metadata.record_last_updated_gmt::DATE) >= 60 
+AND i.location_code ~ '^brk' 
+ORDER BY 1,3

--- a/Misc Queries/Circulation/old in transit.sql
+++ b/Misc Queries/Circulation/old in transit.sql
@@ -1,0 +1,24 @@
+SELECT
+	DISTINCT i.location_code,
+	i.barcode,
+	TRIM(regexp_replace(iprop.call_number,'\|.',' ','g')),
+	bprop.best_author,
+	bprop.best_title,
+	v.field_content,
+	i.itype_code_num,
+	it.name
+FROM sierra_view.varfield v
+	JOIN sierra_view.item_view i ON v.record_id = i.id
+	JOIN sierra_view.item_record_property iprop ON i.id = iprop.item_record_id
+	JOIN sierra_view.bib_record_item_record_link bilink ON bilink.item_record_id = i.id
+	JOIN sierra_view.bib_record_property bprop ON bilink.bib_record_id = bprop.bib_record_id
+	JOIN sierra_view.record_metadata ON record_metadata.id = i.id
+	JOIN sierra_view.itype_property ip ON i.itype_code_num = ip.code_num
+	JOIN sierra_view.itype_property_name it ON ip.id = it.itype_property_id 
+WHERE 
+	field_content LIKE '%TRANSIT%'
+	AND i.item_status_code = 't'
+	AND (current_date - record_metadata.record_last_updated_gmt::date) > 14
+	AND v.varfield_type_code = 'm'
+	AND i.location_code ~ '^"""+libcode.lower()+"""'
+ORDER BY 1,3

--- a/Misc Queries/Circulation/old missing items.sql
+++ b/Misc Queries/Circulation/old missing items.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DISTINCT i.location_code,
+	i.barcode,
+	TRIM(regexp_replace(iprop.call_number,'\|.',' ','g')),
+	v.field_content,
+	bprop.best_author,
+	bprop.best_title,
+	(SELECT v.field_content WHERE field_content LIKE '%TRANSIT%'),
+	i.itype_code_num,
+	it.name,
+	CAST(record_metadata.record_last_updated_gmt AS DATE)
+FROM sierra_view.item_view i
+	LEFT JOIN sierra_view.varfield v ON v.record_id = i.id AND v.varfield_type_code = 'v'
+	JOIN sierra_view.item_record_property iprop ON i.id = iprop.item_record_id
+	JOIN sierra_view.bib_record_item_record_link bilink ON bilink.item_record_id = i.id
+	JOIN sierra_view.bib_record_property bprop ON bilink.bib_record_id = bprop.bib_record_id
+	JOIN sierra_view.record_metadata ON record_metadata.id = i.id
+	JOIN sierra_view.itype_property ip ON i.itype_code_num = ip.code_num
+	JOIN sierra_view.itype_property_name it ON ip.id = it.itype_property_id
+WHERE i.item_status_code = 'm' AND (current_date - record_metadata.record_last_updated_gmt::DATE) >= 60
+AND i.location_code ~ '^"""+libcode.lower()+"""'
+ORDER BY 1,3

--- a/Testing/subject usage.sql
+++ b/Testing/subject usage.sql
@@ -16,7 +16,7 @@ b.id = s.record_id AND s.field_type_code = 'd'*/
 
 WHERE
 /*REPLACE(LOWER(s.content),'-',' ')*/
-REPLACE(d.index_entry,'.','') ~ 'genocide'
+REPLACE(d.index_entry,'.','') ~ '(\y(?!\w*biograph(y|ical))\w*(comic books strips etc))'
 --'(christian (art|antiquities|pilgrims|saints|shrine|travel))|(church (architecture|buildings|decoration)).*guidebooks'
 -- pondering for mysteries 'crimes against(?!.*fiction)'
 

--- a/Testing/unowned report troubleshooting.sql
+++ b/Testing/unowned report troubleshooting.sql
@@ -1,0 +1,206 @@
+/*
+Jeremy Goldstein
+Minuteman Library Network
+Gathers the top titles in the network ,that are not owned locally, in a dei topical area, grouped by a choice of performance metrics
+*/
+WITH hold_count AS
+	(SELECT
+	l.bib_record_id,
+	COUNT(DISTINCT h.id) AS count_holds_on_title
+	--reconciles bib,item and volume level holds
+
+	FROM
+	sierra_view.hold h
+	JOIN
+	sierra_view.bib_record_item_record_link l
+	ON
+	h.record_id = l.item_record_id OR h.record_id = l.bib_record_id
+
+	GROUP BY 1
+	HAVING
+	COUNT(DISTINCT h.id) > 1
+),
+
+unowned AS (
+	SELECT
+	l.bib_record_id
+	FROM
+	sierra_view.bib_record_item_record_link l
+	JOIN
+	sierra_view.item_record i
+	ON
+	l.item_record_id = i.id AND i.item_status_code NOT IN ('000')
+		JOIN
+	sierra_view.record_metadata rm
+	ON i.id = rm.id AND rm.creation_date_gmt::DATE < '2022-09-21'
+	JOIN
+	sierra_view.bib_record br
+	ON
+	l.bib_record_id = br.id	AND br.bcode3 NOT IN ('g','o','r','z','l','q','n') 
+	JOIN
+	sierra_view.phrase_entry d
+	ON
+	br.id = d.record_id AND d.index_tag = 'd' AND d.is_permuted = false
+	--exclude guidebooks
+	AND REPLACE(d.index_entry,'.','') !~ '^\y(?!\w((ecology)|(ecotourism)|(ecosystems)|(environmentalism)|(african american)|(african diaspora)|(blues music)|(freedom trail)|(underground railroad)|(women)|(ethnic restaurants)|
+	(social life and customs)|(older people)|(people with disabilities)|(gay(s|\y(?!(head|john))))|(lesbian)|(bisexual)|(gender)|(sexual minorities)|(indian (art|trails))|(indians of)|(inca(s|n))|
+	(christian (art|antiquities|saints|shrine|travel))|(pilgrims and pilgrimages)|(jews)|(judaism)|((jewish|islamic) architecture)|(convents)|(sacred space)|(sepulchral monuments)|(spanish mission)|(spiritual retreat)|(temples)|(houses of prayer)|(religious institutions)|(monasteries)|(holocaust)|(church (architecture|buildings|decoration))))\w.*((guidebooks)|(description and travel))'
+	AND REPLACE(d.index_entry,'.','') ~ '(east asia)|(asian americans)|(^\y(?!\w*everest)\w*(chin(a(?!\sfictitious)|ese)(?!.*everest)))|(japan(?!ese beetle))|(korea(?!n war))|(taiwan)|(vietnam(?! war))|(cambodia)|(mongolia)|(lao(s|tian))|(myanmar)|(\ymalay)|((?<!muay )\ythai)|(philippin)|(indonesia)|(polynesia)|(brunei)|(east timor)|(pacific island)|(tibet autonomous)|(hmong)|(filipino)|(burm(a|ese(?! (python|cat))))'
+	
+	GROUP BY 1
+	HAVING
+	COUNT(i.id) FILTER(WHERE i.location_code ~ '^nor') = 0
+	AND COUNT(i.id) FILTER(WHERE SUBSTRING(i.location_code,4,1) NOT IN ('y','j','s')) > 0
+	/*
+	SUBSTRING(i.location_code,4,1) NOT IN ('y','j','s') --adult
+	SUBSTRING(i.location_code,4,1) = 'j' --juv
+	SUBSTRING(i.location_code,4,1) = 'y' --ya
+	i.location_code ~ '\w' --all
+	*/
+)
+
+SELECT
+'b'||mb.record_num||'a' AS bib_number,
+b.best_title AS title,
+b.best_author AS author,
+b.publish_year,
+MODE() WITHIN GROUP (ORDER BY CASE
+	WHEN d.index_entry ~ '((\yfiction)|(pictorial works)|(tales)|(\y(?!\w*biography)\w*(comic books strips etc))|(\y(?!\w*biography)\w*(graphic novels))|(\ydrama)|((?<!hi)stories))(( [a-z]+)?)(( translations into [a-z]+)?)$' AND b.material_code NOT IN ('7','8','b','e','j','k','m','n')
+	AND NOT (ml.bib_level_code = 'm' AND ml.record_type_code = 'a' AND f.p33 IN ('0','e','i','p','s','','c')) THEN 'Fiction'
+	ELSE 'Nonfiction'
+END) AS is_fiction,
+SUM(i.last_year_to_date_checkout_total)
+
+/*
+Grouping options
+ROUND(AVG((CAST(((i.checkout_total + i.renewal_total) * loan.est_loan_period) AS NUMERIC (12,2))/(NULLIF((CURRENT_DATE - m.creation_date_gmt::DATE),0)) * 100),2) AS time_checked_out_pct
+ROUND(CAST(SUM(i.checkout_total) + SUM(i.renewal_total) AS NUMERIC (12,2))/CAST(COUNT (i.id) AS NUMERIC (12,2)), 2) AS turnover
+SUM(i.year_to_date_checkout_total + i.last_year_to_date_checkout_total) AS total_checkouts
+SUM(i.checkout_total + i.renewal_total) AS total_circulation
+SUM(i.checkout_total) AS total_checkouts
+SUM(i.year_to_date_checkout_total) AS total_year_to_date_checkouts
+SUM(i.last_year_to_date_checkout_total) AS total_last_year_to_date_checkouts
+COALESCE(h.count_holds_on_title,0) AS total_holds
+*/
+
+FROM
+unowned o
+JOIN
+sierra_view.bib_record_property b
+ON
+o.bib_record_id = b.bib_record_id
+JOIN
+sierra_view.bib_record_item_record_link l
+ON
+b.bib_record_id = l.bib_record_id
+JOIN
+sierra_view.item_record i
+ON
+l.item_record_id = i.id
+JOIN
+sierra_view.record_metadata m
+ON
+i.id = m.id
+JOIN
+sierra_view.record_metadata mb
+ON
+b.bib_record_id = mb.id
+LEFT JOIN
+hold_count AS h
+ON
+b.bib_record_id = h.bib_record_id
+JOIN
+(
+SELECT
+i.itype_code_num,
+ROUND(AVG(EXTRACT (DAY FROM l.est_loan_period))) AS est_loan_period
+
+FROM
+sierra_view.checkout c
+JOIN (SELECT
+CASE
+WHEN f.loanrule_code_num BETWEEN 2 AND 12 OR f.loanrule_code_num BETWEEN 501 AND 509 THEN 'Acton'
+WHEN f.loanrule_code_num BETWEEN 13 AND 23 OR f.loanrule_code_num BETWEEN 510 AND 518 THEN 'Arlington'
+WHEN f.loanrule_code_num BETWEEN 24 AND 34 OR f.loanrule_code_num BETWEEN 519 AND 527 THEN 'Ashland'
+WHEN f.loanrule_code_num BETWEEN 35 AND 45 OR f.loanrule_code_num BETWEEN 528 AND 536 THEN 'Bedford'
+WHEN f.loanrule_code_num BETWEEN 46 AND 56 OR f.loanrule_code_num BETWEEN 537 AND 545 THEN 'Belmont'
+WHEN f.loanrule_code_num BETWEEN 57 AND 67 OR f.loanrule_code_num BETWEEN 546 AND 554 THEN 'Brookline'
+WHEN f.loanrule_code_num BETWEEN 68 AND 78 OR f.loanrule_code_num BETWEEN 555 AND 563 THEN 'Cambridge'
+WHEN f.loanrule_code_num BETWEEN 79 AND 89 OR f.loanrule_code_num BETWEEN 564 AND 572 THEN 'Concord'
+WHEN f.loanrule_code_num BETWEEN 90 AND 100 OR f.loanrule_code_num BETWEEN 573 AND 581 THEN 'Dedham'
+WHEN f.loanrule_code_num BETWEEN 101 AND 111 OR f.loanrule_code_num BETWEEN 582 AND 590 THEN 'Dean'
+WHEN f.loanrule_code_num BETWEEN 112 AND 122 OR f.loanrule_code_num BETWEEN 591 AND 599 THEN 'Dover'
+WHEN f.loanrule_code_num BETWEEN 123 AND 133 OR f.loanrule_code_num BETWEEN 600 AND 608 THEN 'Framingham'
+WHEN f.loanrule_code_num BETWEEN 134 AND 144 OR f.loanrule_code_num BETWEEN 609 AND 617 THEN 'Franklin'
+WHEN f.loanrule_code_num BETWEEN 145 AND 155 OR f.loanrule_code_num BETWEEN 618 AND 626 THEN 'Framingham State'
+WHEN f.loanrule_code_num BETWEEN 156 AND 166 OR f.loanrule_code_num BETWEEN 627 AND 635 THEN 'Holliston'
+WHEN f.loanrule_code_num BETWEEN 167 AND 177 OR f.loanrule_code_num BETWEEN 636 AND 644 THEN 'Lasell'
+WHEN f.loanrule_code_num BETWEEN 178 AND 188 OR f.loanrule_code_num BETWEEN 645 AND 653 THEN 'Lexington'
+WHEN f.loanrule_code_num BETWEEN 189 AND 199 OR f.loanrule_code_num BETWEEN 654 AND 662 THEN 'Lincoln'
+WHEN f.loanrule_code_num BETWEEN 200 AND 210 OR f.loanrule_code_num BETWEEN 663 AND 671 THEN 'Maynard'
+WHEN f.loanrule_code_num BETWEEN 222 AND 232 OR f.loanrule_code_num BETWEEN 681 AND 689 THEN 'Medford'
+WHEN f.loanrule_code_num BETWEEN 233 AND 243 OR f.loanrule_code_num BETWEEN 690 AND 698 THEN 'Millis'
+WHEN f.loanrule_code_num BETWEEN 244 AND 254 OR f.loanrule_code_num BETWEEN 699 AND 707 THEN 'Medfield'
+WHEN f.loanrule_code_num BETWEEN 255 AND 265 OR f.loanrule_code_num BETWEEN 708 AND 716 THEN 'Mount Ida'
+WHEN f.loanrule_code_num BETWEEN 266 AND 276 OR f.loanrule_code_num BETWEEN 717 AND 725 THEN 'Medway'
+WHEN f.loanrule_code_num BETWEEN 277 AND 287 OR f.loanrule_code_num BETWEEN 726 AND 733 THEN 'Natick'
+WHEN f.loanrule_code_num BETWEEN 289 AND 298 OR f.loanrule_code_num BETWEEN 734 AND 743 THEN 'Olin'
+WHEN f.loanrule_code_num BETWEEN 299 AND 309 OR f.loanrule_code_num BETWEEN 744 AND 752 THEN 'Needham'
+WHEN f.loanrule_code_num BETWEEN 310 AND 320 OR f.loanrule_code_num BETWEEN 753 AND 761 THEN 'Norwood'
+WHEN f.loanrule_code_num BETWEEN 321 AND 331 OR f.loanrule_code_num BETWEEN 762 AND 770 THEN 'Newton'
+WHEN f.loanrule_code_num BETWEEN 332 AND 342 OR f.loanrule_code_num BETWEEN 771 AND 779 THEN 'Somerville'
+WHEN f.loanrule_code_num BETWEEN 343 AND 353 OR f.loanrule_code_num BETWEEN 780 AND 788 THEN 'Stow'
+WHEN f.loanrule_code_num BETWEEN 354 AND 364 OR f.loanrule_code_num BETWEEN 789 AND 797 THEN 'Sudbury'
+WHEN f.loanrule_code_num BETWEEN 365 AND 375 OR f.loanrule_code_num BETWEEN 798 AND 806 THEN 'Watertown'
+WHEN f.loanrule_code_num BETWEEN 376 AND 386 OR f.loanrule_code_num BETWEEN 807 AND 815 THEN 'Wellesley'
+WHEN f.loanrule_code_num BETWEEN 387 AND 397 OR f.loanrule_code_num BETWEEN 816 AND 824 THEN 'Winchester'
+WHEN f.loanrule_code_num BETWEEN 398 AND 408 OR f.loanrule_code_num BETWEEN 825 AND 833 THEN 'Waltham'
+WHEN f.loanrule_code_num BETWEEN 409 AND 419 OR f.loanrule_code_num BETWEEN 834 AND 842 THEN 'Woburn'
+WHEN f.loanrule_code_num BETWEEN 420 AND 430 OR f.loanrule_code_num BETWEEN 843 AND 851 THEN 'Weston'
+WHEN f.loanrule_code_num BETWEEN 431 AND 441 OR f.loanrule_code_num BETWEEN 852 AND 860 THEN 'Westwood'
+WHEN f.loanrule_code_num BETWEEN 442 AND 452 OR f.loanrule_code_num BETWEEN 861 AND 869 THEN 'Wayland'
+WHEN f.loanrule_code_num BETWEEN 453 AND 463 OR f.loanrule_code_num BETWEEN 870 AND 878 THEN 'Pine Manor'
+WHEN f.loanrule_code_num BETWEEN 464 AND 474 OR f.loanrule_code_num BETWEEN 879 AND 887 THEN 'Regis'
+WHEN f.loanrule_code_num BETWEEN 475 AND 485 OR f.loanrule_code_num BETWEEN 888 AND 896 THEN 'Sherborn'
+Else 'Other'
+END AS checkout_location,
+f.loanrule_code_num AS loanrule_num,
+MIN(AGE(f.due_gmt::date,f.checkout_gmt::date)) AS est_loan_period
+
+FROM
+sierra_view.fine f
+WHERE f.loanrule_code_num NOT IN ('1','288','493','494','495','496','497','498','999')
+GROUP BY 1,2
+HAVING COUNT(f.loanrule_code_num) > 5
+ORDER BY 1,2
+) l
+ON
+c.loanrule_code_num = l.loanrule_num
+JOIN
+sierra_view.item_record i
+ON
+c.item_record_id = i.id
+
+GROUP BY 1) loan
+ON
+i.itype_code_num = loan.itype_code_num
+JOIN
+sierra_view.phrase_entry d
+ON
+b.bib_record_id = d.record_id AND d.index_tag = 'd' AND d.is_permuted = false
+LEFT JOIN
+sierra_view.control_field f
+ON
+b.bib_record_id = f.record_id
+LEFT JOIN
+sierra_view.leader_field ml
+ON
+b.bib_record_id = ml.record_id
+
+WHERE
+b.material_code IN ('a')
+
+GROUP BY
+1,2,3,4,h.count_holds_on_title
+ORDER BY 6 DESC
+LIMIT 400


### PR DESCRIPTION
added bib level holds where items have volumes